### PR TITLE
Allow typst files to change their output html path

### DIFF
--- a/src/compiler/pages.rs
+++ b/src/compiler/pages.rs
@@ -71,24 +71,22 @@ pub fn process_page(
     deps_mtime: Option<SystemTime>,
     log_file: bool,
 ) -> Result<Option<PageMeta>> {
-    let mut page = PageMeta::from_paths(path.to_path_buf(), config)?;
+    // Compile the page and get metadata
+    let (html_content, content_meta) = compile_meta(path, config)?;
+    let mut page = PageMeta::from_paths(path.to_path_buf(), config, content_meta)?;
 
     // Check if up-to-date
     if !clean && is_up_to_date(path, &page.paths.html, deps_mtime) {
         return Ok(None);
     }
 
-    // Compile the page and get metadata
-    let (html_content, content_meta) = compile_meta(path, config)?;
-
     // Skip drafts
-    if is_draft(content_meta.as_ref()) {
+    if is_draft(page.content_meta.as_ref()) {
         // Remove from global data if it was previously published
         // (This handles the case where a page is marked as draft after being published)
         return Ok(None);
     }
 
-    page.content_meta = content_meta;
     page.compiled_html = Some(html_content);
 
     // Update global site data for virtual JSON files
@@ -136,7 +134,9 @@ fn write_page(
 
     // Post-process and write
     // Check if the source file was named "index.typ" for relative path resolution
-    let is_source_index = page.paths.source
+    let is_source_index = page
+        .paths
+        .source
         .file_stem()
         .is_some_and(|stem| stem == "index");
     let html_content = process_html(&page.paths.html, &html_content, config, is_source_index)?;
@@ -153,7 +153,9 @@ pub fn compile_meta(path: &Path, config: &SiteConfig) -> Result<(Vec<u8>, Option
     if config.build.typst.use_lib {
         let root = config.get_root();
         let result = typst_lib::compile_meta(path, root, TOLA_META_LABEL)?;
-        let meta = result.metadata.and_then(|json| serde_json::from_value(json).ok());
+        let meta = result
+            .metadata
+            .and_then(|json| serde_json::from_value(json).ok());
 
         // Record dependencies for incremental rebuild
         super::deps::DEPENDENCY_GRAPH
@@ -173,7 +175,9 @@ pub fn query_meta(path: &Path, config: &SiteConfig) -> Option<ContentMeta> {
     if config.build.typst.use_lib {
         let root = config.get_root();
         let result = typst_lib::compile_meta(path, root, TOLA_META_LABEL).ok()?;
-        result.metadata.and_then(|json| serde_json::from_value(json).ok())
+        result
+            .metadata
+            .and_then(|json| serde_json::from_value(json).ok())
     } else {
         query_meta_cli(path, config)
     }
@@ -235,6 +239,7 @@ fn is_draft(meta: Option<&ContentMeta>) -> bool {
 fn page_meta_to_data(page: &PageMeta) -> PageData {
     let content = page.content_meta.as_ref();
     PageData {
+        source: page.paths.source.clone(),
         url: page.paths.url_path.clone(),
         title: content
             .and_then(|c| c.title.clone())
@@ -243,9 +248,7 @@ fn page_meta_to_data(page: &PageMeta) -> PageData {
         date: content.and_then(|c| c.date.clone()),
         update: content.and_then(|c| c.update.clone()),
         author: content.and_then(|c| c.author.clone()),
-        tags: content
-            .map(|c| c.tags.clone())
-            .unwrap_or_default(),
+        tags: content.map(|c| c.tags.clone()).unwrap_or_default(),
         draft: content.is_some_and(|c| c.draft),
     }
 }
@@ -273,8 +276,6 @@ pub fn collect_metadata(
     let results: Vec<Result<Option<(std::path::PathBuf, PageMeta)>>> = typ_files
         .par_iter()
         .map(|path| {
-            let page = PageMeta::from_paths(path.clone(), config)?;
-
             // Compile to extract metadata (HTML discarded)
             let content_meta = if config.build.typst.use_lib {
                 let root = config.get_root();
@@ -285,19 +286,19 @@ pub fn collect_metadata(
                     .write()
                     .record_dependencies(path, &result.accessed_files);
 
-                result.metadata.and_then(|json| serde_json::from_value(json).ok())
+                result
+                    .metadata
+                    .and_then(|json| serde_json::from_value(json).ok())
             } else {
                 query_meta(path, config)
             };
+            let page = PageMeta::from_paths(path.clone(), config, content_meta)?;
 
             // Skip drafts
-            if is_draft(content_meta.as_ref()) {
+            if page.content_meta.as_ref().is_some_and(|meta| meta.draft) {
                 on_progress();
                 return Ok(None);
             }
-
-            let mut page = page;
-            page.content_meta = content_meta;
 
             // Store in global data
             GLOBAL_SITE_DATA.insert_page(page_meta_to_data(&page));
@@ -334,12 +335,10 @@ pub fn compile_pages_with_data(
     let results: Vec<Result<PageMeta>> = paths
         .par_iter()
         .map(|path| {
-            let mut page = PageMeta::from_paths(path.clone(), config)?;
-
             // Compile with complete data
             let (html, content_meta) = compile_meta(path, config)?;
 
-            page.content_meta = content_meta;
+            let mut page = PageMeta::from_paths(path.clone(), config, content_meta)?;
             page.compiled_html = Some(html);
 
             // Write the page
@@ -388,8 +387,6 @@ pub fn collect_pages(config: &SiteConfig) -> Result<Pages> {
     let results: Vec<Result<Option<PageMeta>>> = typ_files
         .par_iter()
         .map(|path| {
-            let mut page = PageMeta::from_paths(path.clone(), config)?;
-
             let (html, content_meta) = if config.build.typst.use_lib {
                 // Lib mode: compile once, get both HTML and metadata (metadata may be None)
                 let result = compile_meta(path, config)?;
@@ -398,13 +395,13 @@ pub fn collect_pages(config: &SiteConfig) -> Result<Pages> {
                 // CLI mode: only query metadata, compile later (metadata may be None)
                 (None, query_meta(path, config))
             };
+            let mut page = PageMeta::from_paths(path.clone(), config, content_meta)?;
 
             // Skip drafts
-            if is_draft(content_meta.as_ref()) {
+            if is_draft(page.content_meta.as_ref()) {
                 return Ok(None);
             }
 
-            page.content_meta = content_meta;
             page.compiled_html = html;
             Ok(Some(page))
         })
@@ -550,6 +547,36 @@ mod tests {
     }
 
     #[test]
+    fn compile_meta_custom_html_path() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("test.typ");
+
+        fs::write(
+            &file_path,
+            r#"#metadata((
+      html_path: "my_post.html"
+    )) <tola-meta>"#,
+        )
+        .unwrap();
+
+        let mut config = SiteConfig::default();
+        config.build.typst.use_lib = true;
+        config.set_root(dir.path());
+
+        assert_eq!(
+            compile_meta(&file_path, &config)
+                .unwrap()
+                .1
+                .unwrap()
+                .url
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "my_post.html"
+        );
+    }
+
+    #[test]
     fn test_compile_error_returns_err() {
         let dir = TempDir::new().unwrap();
         let file_path = dir.path().join("invalid.typ");
@@ -579,7 +606,7 @@ mod tests {
         fs::write(&file_path, "= Test").unwrap();
 
         let config = make_test_config(content_dir.clone(), output_dir);
-        let page = PageMeta::from_paths(file_path, &config);
+        let page = PageMeta::from_paths(file_path, &config, None);
 
         assert!(page.is_ok());
         let page = page.unwrap();
@@ -598,7 +625,7 @@ mod tests {
         fs::write(&file_path, "= Hello").unwrap();
 
         let config = make_test_config(content_dir.clone(), output_dir);
-        let page = PageMeta::from_paths(file_path, &config);
+        let page = PageMeta::from_paths(file_path, &config, None);
 
         assert!(page.is_ok());
         let page = page.unwrap();

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -197,6 +197,8 @@ impl SiteDataStore {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
 
     #[test]
@@ -204,6 +206,7 @@ mod tests {
         let store = SiteDataStore::new();
 
         store.insert_page(PageData {
+            source: PathBuf::from("posts/first.typ"),
             url: "/posts/first/".to_string(),
             title: "First Post".to_string(),
             summary: None,
@@ -215,6 +218,7 @@ mod tests {
         });
 
         store.insert_page(PageData {
+            source: PathBuf::from("posts/second.typ"),
             url: "/posts/second/".to_string(),
             title: "Second Post".to_string(),
             summary: None,
@@ -237,6 +241,7 @@ mod tests {
         let store = SiteDataStore::new();
 
         store.insert_page(PageData {
+            source: PathBuf::from("a.typ"),
             url: "/a/".to_string(),
             title: "A".to_string(),
             summary: None,
@@ -248,6 +253,7 @@ mod tests {
         });
 
         store.insert_page(PageData {
+            source: PathBuf::from("b.typ"),
             url: "/b/".to_string(),
             title: "B".to_string(),
             summary: None,
@@ -273,6 +279,7 @@ mod tests {
         let store = SiteDataStore::new();
 
         store.insert_page(PageData {
+            source: PathBuf::from("draft.typ"),
             url: "/draft/".to_string(),
             title: "Draft".to_string(),
             summary: None,
@@ -292,6 +299,7 @@ mod tests {
         let store = SiteDataStore::new();
 
         store.insert_page(PageData {
+            source: PathBuf::from("published.typ"),
             url: "/published/".to_string(),
             title: "Published".to_string(),
             summary: None,
@@ -303,6 +311,7 @@ mod tests {
         });
 
         store.insert_page(PageData {
+            source: PathBuf::from("draft.typ"),
             url: "/draft/".to_string(),
             title: "Draft".to_string(),
             summary: None,
@@ -323,6 +332,7 @@ mod tests {
         let store = SiteDataStore::new();
 
         store.insert_page(PageData {
+            source: PathBuf::from("b.typ"),
             url: "/b/".to_string(),
             title: "Beta".to_string(),
             summary: None,
@@ -334,6 +344,7 @@ mod tests {
         });
 
         store.insert_page(PageData {
+            source: PathBuf::from("a.typ"),
             url: "/a/".to_string(),
             title: "Alpha".to_string(),
             summary: None,
@@ -356,6 +367,7 @@ mod tests {
         let store = SiteDataStore::new();
 
         store.insert_page(PageData {
+            source: PathBuf::from("no-date.typ"),
             url: "/no-date/".to_string(),
             title: "No Date".to_string(),
             summary: None,
@@ -367,6 +379,7 @@ mod tests {
         });
 
         store.insert_page(PageData {
+            source: PathBuf::from("has-date.typ"),
             url: "/has-date/".to_string(),
             title: "Has Date".to_string(),
             summary: None,
@@ -389,6 +402,7 @@ mod tests {
         let store = SiteDataStore::new();
 
         store.insert_page(PageData {
+            source: PathBuf::from("test.typ"),
             url: "/test/".to_string(),
             title: "Test".to_string(),
             summary: None,

--- a/src/data/types.rs
+++ b/src/data/types.rs
@@ -2,6 +2,8 @@
 //!
 //! These types are serialized to JSON and exposed to Typst templates.
 
+use std::path::PathBuf;
+
 use serde::Serialize;
 
 /// Metadata for a single page, exposed in `/_data/pages.json`.
@@ -9,6 +11,9 @@ use serde::Serialize;
 /// This is the data available to Typst templates when reading the pages index.
 #[derive(Debug, Clone, Serialize)]
 pub struct PageData {
+    /// Path to the original .typ file
+    pub source: PathBuf,
+
     /// Page URL path (e.g., "/posts/hello-world/")
     pub url: String,
 

--- a/src/generator/rss.rs
+++ b/src/generator/rss.rs
@@ -175,6 +175,7 @@ mod tests {
             },
             lastmod: None,
             content_meta: Some(ContentMeta {
+                url: None,
                 title: Some(title.to_string()),
                 summary: summary.map(String::from),
                 date: Some(date.to_string()),


### PR DESCRIPTION
This PR allows typst files to use a custom URL by adding `url` field in `<tola-meta>`

These files also receive the original path to the file

Closes https://github.com/tola-rs/tola-ssg/issues/40