### PR TITLE
Add CI that checks for code being formatted by `rustfmt`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: Check
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  cargo-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - run: cargo fmt --check

--- a/src/build.rs
+++ b/src/build.rs
@@ -21,21 +21,17 @@
 //! ```
 
 use crate::{
-    compiler::{
-        collect_all_files, collect_metadata, compile_pages_with_data,
-        process_asset, process_rel_asset,
-    },
     compiler::meta::Pages,
+    compiler::{
+        collect_all_files, collect_metadata, compile_pages_with_data, process_asset,
+        process_rel_asset,
+    },
     config::SiteConfig,
     data::virtual_fs,
     log,
     logger::ProgressBars,
     typst_lib,
-    utils::{
-        category::get_deps_mtime,
-        css,
-        git,
-    },
+    utils::{category::get_deps_mtime, css, git},
 };
 use anyhow::{Context, Result, anyhow};
 use gix::ThreadSafeRepository;

--- a/src/compiler/assets.rs
+++ b/src/compiler/assets.rs
@@ -1,8 +1,8 @@
-use crate::config::SiteConfig;
-use crate::compiler::meta::AssetMeta;
 use crate::compiler::is_up_to_date;
-use crate::utils::css;
+use crate::compiler::meta::AssetMeta;
+use crate::config::SiteConfig;
 use crate::log;
+use crate::utils::css;
 use anyhow::{Result, anyhow};
 use std::fs;
 use std::path::Path;
@@ -83,8 +83,12 @@ pub fn process_rel_asset(
 /// Delegates to `utils::css::rebuild_tailwind` with asset path resolution.
 /// When `quiet` is true, output is suppressed (for watch mode).
 pub fn rebuild_tailwind(config: &SiteConfig, quiet: bool) -> Result<()> {
-    css::rebuild_tailwind(config, |input| {
-        let meta = AssetMeta::from_source(input.to_path_buf(), config)?;
-        Ok(meta.paths.dest)
-    }, quiet)
+    css::rebuild_tailwind(
+        config,
+        |input| {
+            let meta = AssetMeta::from_source(input.to_path_buf(), config)?;
+            Ok(meta.paths.dest)
+        },
+        quiet,
+    )
 }

--- a/src/compiler/meta.rs
+++ b/src/compiler/meta.rs
@@ -390,10 +390,19 @@ where
 enum TypstElement {
     Space,
     Linebreak,
-    Text { text: String },
-    Strike { text: String },
-    Link { dest: String, body: Box<Self> },
-    Sequence { children: Vec<Self> },
+    Text {
+        text: String,
+    },
+    Strike {
+        text: String,
+    },
+    Link {
+        dest: String,
+        body: Box<Self>,
+    },
+    Sequence {
+        children: Vec<Self>,
+    },
     #[serde(other)]
     Unknown,
 }
@@ -409,9 +418,7 @@ impl TypstElement {
             Self::Link { dest, body } => {
                 format!("<a href=\"{dest}\">{}</a>", body.to_html())
             }
-            Self::Sequence { children } => {
-                children.iter().map(Self::to_html).collect()
-            }
+            Self::Sequence { children } => children.iter().map(Self::to_html).collect(),
             Self::Unknown => String::new(),
         }
     }
@@ -806,7 +813,10 @@ mod tests {
         } else {
             panic!("Expected Link element");
         }
-        assert_eq!(elem.to_html(), r#"<a href="https://example.com">click here</a>"#);
+        assert_eq!(
+            elem.to_html(),
+            r#"<a href="https://example.com">click here</a>"#
+        );
     }
 
     #[test]
@@ -843,7 +853,10 @@ mod tests {
             ]
         }"#;
         let elem: TypstElement = serde_json::from_str(json).unwrap();
-        assert_eq!(elem.to_html(), r#"Start <a href="https://rust-lang.org">Rust</a> is great"#);
+        assert_eq!(
+            elem.to_html(),
+            r#"Start <a href="https://rust-lang.org">Rust</a> is great"#
+        );
     }
 
     // ========================================================================
@@ -864,7 +877,10 @@ mod tests {
 
     #[test]
     fn test_html_escape_mixed() {
-        assert_eq!(html_escape("<a href=\"#\">link & text</a>"), "&lt;a href=&quot;#&quot;&gt;link &amp; text&lt;/a&gt;");
+        assert_eq!(
+            html_escape("<a href=\"#\">link & text</a>"),
+            "&lt;a href=&quot;#&quot;&gt;link &amp; text&lt;/a&gt;"
+        );
     }
 
     #[test]
@@ -899,7 +915,10 @@ mod tests {
         }"#;
         let meta: ContentMeta = serde_json::from_str(json).unwrap();
         assert_eq!(meta.title, Some("Post".to_string()));
-        assert_eq!(meta.summary, Some(r#"This is a <a href="https://example.com">link</a> in summary"#.to_string()));
+        assert_eq!(
+            meta.summary,
+            Some(r#"This is a <a href="https://example.com">link</a> in summary"#.to_string())
+        );
     }
 
     #[test]
@@ -922,7 +941,10 @@ mod tests {
     fn test_content_meta_summary_with_html_escape() {
         let json = r#"{"summary": {"func": "text", "text": "Use <code> & \"quotes\""}}"#;
         let meta: ContentMeta = serde_json::from_str(json).unwrap();
-        assert_eq!(meta.summary, Some("Use &lt;code&gt; &amp; &quot;quotes&quot;".to_string()));
+        assert_eq!(
+            meta.summary,
+            Some("Use &lt;code&gt; &amp; &quot;quotes&quot;".to_string())
+        );
     }
 
     #[test]

--- a/src/compiler/watch.rs
+++ b/src/compiler/watch.rs
@@ -21,8 +21,8 @@ use crate::compiler::pages::process_page;
 use crate::config::SiteConfig;
 use crate::data::virtual_fs;
 use crate::logger::ProgressBars;
-use crate::utils::category::{categorize_path, normalize_path, FileCategory};
-use anyhow::{bail, Result};
+use crate::utils::category::{FileCategory, categorize_path, normalize_path};
+use anyhow::{Result, bail};
 use rayon::prelude::*;
 use std::path::PathBuf;
 
@@ -40,11 +40,7 @@ use std::path::PathBuf;
 /// * `clean` - If true, skip up-to-date checks (used when dependencies changed)
 ///
 /// Returns the number of files processed on success, or an error if any file processing fails.
-pub fn process_watched_files(
-    files: &[PathBuf],
-    config: &SiteConfig,
-    clean: bool,
-) -> Result<usize> {
+pub fn process_watched_files(files: &[PathBuf], config: &SiteConfig, clean: bool) -> Result<usize> {
     let (content_files, asset_files) = categorize_files(files, config);
 
     let progress = ProgressBars::new_filtered(&[

--- a/src/config/build.rs
+++ b/src/config/build.rs
@@ -470,14 +470,17 @@ mod tests {
     #[test]
     fn test_slug_mode_parsing() {
         // Test "full"
-        let config: SiteConfig = toml::from_str(r#"
+        let config: SiteConfig = toml::from_str(
+            r#"
             [base]
             title = "Test"
             description = "Test"
             [build.slug]
             path = "full"
             fragment = "full"
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
         assert!(matches!(config.build.slug.path, SlugMode::Full));
         assert!(matches!(config.build.slug.fragment, SlugMode::Full));
 
@@ -821,7 +824,10 @@ mod tests {
         "#;
         // This should fail because path_prefix is not a valid config field
         let result: Result<SiteConfig, _> = toml::from_str(config);
-        assert!(result.is_err(), "path_prefix should not be accepted in config");
+        assert!(
+            result.is_err(),
+            "path_prefix should not be accepted in config"
+        );
     }
 
     #[test]
@@ -1045,7 +1051,10 @@ mod tests {
             command = ["npx", "tailwindcss"]
         "#;
         let config: SiteConfig = toml::from_str(config).unwrap();
-        assert_eq!(config.build.css.tailwind.command, vec!["npx", "tailwindcss"]);
+        assert_eq!(
+            config.build.css.tailwind.command,
+            vec!["npx", "tailwindcss"]
+        );
     }
 
     #[test]
@@ -1064,23 +1073,32 @@ mod tests {
     #[test]
     fn test_slug_separator_parsing() {
         // Test "dash"
-        let config: SiteConfig = toml::from_str(r#"
+        let config: SiteConfig = toml::from_str(
+            r#"
             [base]
             title = "Test"
             description = "Test"
             [build.slug]
             separator = "dash"
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
         assert!(matches!(config.build.slug.separator, SlugSeparator::Dash));
 
         // Test "underscore"
-        let config: SiteConfig = toml::from_str(r#"
+        let config: SiteConfig = toml::from_str(
+            r#"
             [base]
             title = "Test"
             description = "Test"
             [build.slug]
             separator = "underscore"
-        "#).unwrap();
-        assert!(matches!(config.build.slug.separator, SlugSeparator::Underscore));
+        "#,
+        )
+        .unwrap();
+        assert!(matches!(
+            config.build.slug.separator,
+            SlugSeparator::Underscore
+        ));
     }
 }

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -10,7 +10,6 @@ pub const fn r#true() -> bool {
     true
 }
 
-
 pub const fn r#false() -> bool {
     false
 }

--- a/src/config/handle.rs
+++ b/src/config/handle.rs
@@ -84,7 +84,9 @@ pub fn reload_config() -> anyhow::Result<bool> {
     use std::fs;
 
     let c = cfg();
-    let cli = c.cli.expect("CLI should be set in config during initialization");
+    let cli = c
+        .cli
+        .expect("CLI should be set in config during initialization");
 
     // Read raw content to check for changes
     // Using config_path form current config which is absolute path
@@ -121,11 +123,11 @@ pub fn init_config(config: SiteConfig) {
 
     // Initialize hash if file exists
     if config.config_path.exists()
-        && let Ok(content) = fs::read_to_string(&config.config_path) {
-            let hash = crate::utils::hash::compute(content.as_bytes());
-            CONFIG_HASH.store(hash, std::sync::atomic::Ordering::Relaxed);
-        }
+        && let Ok(content) = fs::read_to_string(&config.config_path)
+    {
+        let hash = crate::utils::hash::compute(content.as_bytes());
+        CONFIG_HASH.store(hash, std::sync::atomic::Ordering::Relaxed);
+    }
 
     CONFIG.store(Arc::new(config));
 }
-

--- a/src/config/paths.rs
+++ b/src/config/paths.rs
@@ -175,7 +175,10 @@ mod tests {
     #[test]
     fn test_url_for_filename_with_prefix() {
         let paths = PathResolver::new(Path::new("/public"), Path::new("my-project"));
-        assert_eq!(paths.url_for_filename("styles.css"), "/my-project/styles.css");
+        assert_eq!(
+            paths.url_for_filename("styles.css"),
+            "/my-project/styles.css"
+        );
     }
 
     #[test]
@@ -193,7 +196,10 @@ mod tests {
     #[test]
     fn test_url_for_rel_path_nested_prefix() {
         let paths = PathResolver::new(Path::new("/public"), Path::new("sites/blog"));
-        assert_eq!(paths.url_for_rel_path("img/logo.png"), "/sites/blog/img/logo.png");
+        assert_eq!(
+            paths.url_for_rel_path("img/logo.png"),
+            "/sites/blog/img/logo.png"
+        );
     }
 
     #[test]

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -28,7 +28,12 @@ struct JsonCache {
 ///
 /// - Items with dates come before items without dates
 /// - Items with same date are sorted by title
-fn compare_by_date<T: AsRef<str>>(a_date: &Option<String>, b_date: &Option<String>, a_title: T, b_title: T) -> std::cmp::Ordering {
+fn compare_by_date<T: AsRef<str>>(
+    a_date: &Option<String>,
+    b_date: &Option<String>,
+    a_title: T,
+    b_title: T,
+) -> std::cmp::Ordering {
     use std::cmp::Ordering;
     match (b_date, a_date) {
         (Some(date_b), Some(date_a)) => date_a.cmp(date_b).reverse(),
@@ -92,10 +97,7 @@ impl SiteDataStore {
     /// Draft pages are excluded from the output.
     pub fn get_pages(&self) -> Vec<PageData> {
         let pages = self.pages.read();
-        let mut result: Vec<_> = pages.values()
-            .filter(|p| !p.draft)
-            .cloned()
-            .collect();
+        let mut result: Vec<_> = pages.values().filter(|p| !p.draft).cloned().collect();
         result.sort_by(|a, b| compare_by_date(&a.date, &b.date, &a.title, &b.title));
         result
     }

--- a/src/data/virtual_fs.rs
+++ b/src/data/virtual_fs.rs
@@ -36,10 +36,7 @@ pub fn is_virtual_data_path(path: &Path) -> bool {
 
     // Handle both absolute paths and root-relative paths
     if path_str.contains("/_data/") {
-        let suffix = path_str
-            .rsplit("/_data/")
-            .next()
-            .unwrap_or("");
+        let suffix = path_str.rsplit("/_data/").next().unwrap_or("");
 
         return VIRTUAL_FILES.iter().any(|(name, _)| *name == suffix);
     }
@@ -59,9 +56,7 @@ pub fn is_virtual_data_path(path: &Path) -> bool {
 pub fn read_virtual_data(path: &Path) -> Option<Vec<u8>> {
     let path_str = path.to_string_lossy();
 
-    let suffix = path_str
-        .rsplit("/_data/")
-        .next()?;
+    let suffix = path_str.rsplit("/_data/").next()?;
 
     for (name, generator) in VIRTUAL_FILES {
         if *name == suffix {
@@ -107,7 +102,9 @@ mod tests {
         assert!(is_virtual_data_path(Path::new("/_data/pages.json")));
         assert!(is_virtual_data_path(Path::new("/_data/tags.json")));
         assert!(is_virtual_data_path(Path::new("/project/_data/pages.json")));
-        assert!(is_virtual_data_path(Path::new("/some/path/_data/tags.json")));
+        assert!(is_virtual_data_path(Path::new(
+            "/some/path/_data/tags.json"
+        )));
 
         assert!(!is_virtual_data_path(Path::new("/_data/unknown.json")));
         assert!(!is_virtual_data_path(Path::new("/regular/file.json")));

--- a/src/generator/rss.rs
+++ b/src/generator/rss.rs
@@ -8,7 +8,7 @@ use crate::{
     log,
     utils::{
         date::DateTimeUtc,
-        minify::{minify, MinifyType},
+        minify::{MinifyType, minify},
     },
 };
 use anyhow::{Ok, Result, anyhow};
@@ -43,10 +43,7 @@ impl<'a> RssFeed<'a> {
     ///
     /// Pages without content metadata are silently skipped.
     fn build(config: &'a SiteConfig, pages: &'a Pages) -> Result<Self> {
-        let pages: Vec<_> = pages
-            .iter()
-            .filter(|p| p.content_meta.is_some())
-            .collect();
+        let pages: Vec<_> = pages.iter().filter(|p| p.content_meta.is_some()).collect();
 
         Ok(Self { config, pages })
     }

--- a/src/generator/sitemap.rs
+++ b/src/generator/sitemap.rs
@@ -14,7 +14,12 @@
 //! </urlset>
 //! ```
 
-use crate::{compiler::meta::Pages, config::SiteConfig, log, utils::minify::{minify, MinifyType}};
+use crate::{
+    compiler::meta::Pages,
+    config::SiteConfig,
+    log,
+    utils::minify::{MinifyType, minify},
+};
 use anyhow::{Context, Result};
 use std::borrow::Cow;
 use std::fs;
@@ -133,7 +138,7 @@ fn escape_xml(s: &str) -> Cow<'_, str> {
             .replace('<', "&lt;")
             .replace('>', "&gt;")
             .replace('"', "&quot;")
-            .replace('\'', "&apos;")
+            .replace('\'', "&apos;"),
     )
 }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -180,7 +180,11 @@ impl ProgressBars {
     /// }
     /// ```
     pub fn new_filtered(modules: &[(&'static str, usize)]) -> Option<Self> {
-        let filtered: Vec<_> = modules.iter().filter(|(_, count)| *count > 0).copied().collect();
+        let filtered: Vec<_> = modules
+            .iter()
+            .filter(|(_, count)| *count > 0)
+            .copied()
+            .collect();
         let total: usize = filtered.iter().map(|(_, c)| c).sum();
 
         if total <= 1 {
@@ -235,7 +239,12 @@ impl ProgressBars {
         let lines_up = (self.bars.len() - bar.row) as u16;
         execute!(stdout, cursor::MoveUp(lines_up)).ok();
         execute!(stdout, Clear(ClearType::CurrentLine)).ok();
-        write!(stdout, "{} [{}] {}", bar.prefix, progress_bar, progress_text).ok();
+        write!(
+            stdout,
+            "{} [{}] {}",
+            bar.prefix, progress_bar, progress_text
+        )
+        .ok();
         execute!(stdout, cursor::MoveDown(lines_up)).ok();
         write!(stdout, "\r").ok();
         stdout.flush().ok();
@@ -402,7 +411,10 @@ impl WatchStatus {
 
     /// Display unchanged message (dimmed).
     pub fn unchanged(&mut self, path: &str) {
-        self.display("".to_string(), &format!("unchanged: {path}").dimmed().to_string());
+        self.display(
+            "".to_string(),
+            &format!("unchanged: {path}").dimmed().to_string(),
+        );
     }
 
     /// Display error message (✗ prefix, red) with optional detail.

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use anyhow::Result;
 use build::build_site;
 use clap::Parser;
 use cli::{Cli, Commands};
-use config::{cfg, init_config, SiteConfig};
+use config::{SiteConfig, cfg, init_config};
 use deploy::deploy_site;
 use generator::{rss::build_rss, sitemap::build_sitemap};
 use gix::ThreadSafeRepository;
@@ -54,13 +54,10 @@ fn build_all() -> Result<ThreadSafeRepository> {
     let (repo, pages) = build_site(&c, false)?;
 
     // Generate rss and sitemap in parallel using collected pages
-    let (rss_result, sitemap_result) = rayon::join(
-        || build_rss(&c, &pages),
-        || build_sitemap(&c, &pages),
-    );
+    let (rss_result, sitemap_result) =
+        rayon::join(|| build_rss(&c, &pages), || build_sitemap(&c, &pages));
 
     rss_result?;
     sitemap_result?;
     Ok(repo)
 }
-

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -27,7 +27,11 @@
 //!              (public/ dir)
 //! ```
 
-use crate::{config::{cfg, SiteConfig}, log, watch::watch_for_changes_blocking};
+use crate::{
+    config::{SiteConfig, cfg},
+    log,
+    watch::watch_for_changes_blocking,
+};
 use anyhow::{Context, Result};
 use std::{
     fs,
@@ -275,7 +279,11 @@ fn guess_content_type(path: &Path) -> &'static str {
 /// - Shows folder/file icons
 /// - Provides parent directory navigation
 /// - Falls back to welcome page if directory is empty
-fn generate_directory_listing(dir_path: &PathBuf, request_path: &str, data_dir_name: &str) -> std::io::Result<String> {
+fn generate_directory_listing(
+    dir_path: &PathBuf,
+    request_path: &str,
+    data_dir_name: &str,
+) -> std::io::Result<String> {
     let entries: Vec<_> = fs::read_dir(dir_path)?
         .filter_map(Result::ok)
         .filter(|entry| {
@@ -329,7 +337,8 @@ fn generate_directory_listing(dir_path: &PathBuf, request_path: &str, data_dir_n
         )
     };
 
-    #[allow(clippy::literal_string_with_formatting_args)] // These are template placeholders, not format args
+    #[allow(clippy::literal_string_with_formatting_args)]
+    // These are template placeholders, not format args
     Ok(DIRECTORY_TEMPLATE
         .replace("{path}", request_path)
         .replace("{parent_link}", &parent_link)

--- a/src/typst_lib/diagnostic.rs
+++ b/src/typst_lib/diagnostic.rs
@@ -29,9 +29,9 @@
 use std::fmt::Write;
 
 use colored::{ColoredString, Colorize};
+use typst::World;
 use typst::diag::{Severity, SourceDiagnostic};
 use typst::syntax::Span;
-use typst::World;
 
 // ============================================================================
 // Gutter Characters
@@ -177,7 +177,11 @@ struct SnippetWriter<'a> {
 }
 
 impl<'a> SnippetWriter<'a> {
-    const fn new(output: &'a mut String, theme: &'a DiagnosticTheme, line_num_width: usize) -> Self {
+    const fn new(
+        output: &'a mut String,
+        theme: &'a DiagnosticTheme,
+        line_num_width: usize,
+    ) -> Self {
         Self {
             output,
             theme,
@@ -327,12 +331,12 @@ pub fn format_diagnostics<W: World>(world: &W, diagnostics: &[SourceDiagnostic])
 /// Count errors and warnings in a diagnostic list.
 #[allow(dead_code)]
 pub fn count_diagnostics(diagnostics: &[SourceDiagnostic]) -> (usize, usize) {
-    diagnostics.iter().fold((0, 0), |(errors, warnings), d| {
-        match d.severity {
+    diagnostics
+        .iter()
+        .fold((0, 0), |(errors, warnings), d| match d.severity {
             Severity::Error => (errors + 1, warnings),
             Severity::Warning => (errors, warnings + 1),
-        }
-    })
+        })
 }
 
 /// Check if there are any errors in the diagnostics.
@@ -353,7 +357,8 @@ pub fn filter_html_warnings(diagnostics: &[SourceDiagnostic]) -> Vec<SourceDiagn
                 return true;
             }
             // Filter out HTML export warning
-            !d.message.contains("html export is under active development")
+            !d.message
+                .contains("html export is under active development")
         })
         .cloned()
         .collect()

--- a/src/typst_lib/font.rs
+++ b/src/typst_lib/font.rs
@@ -92,9 +92,8 @@ fn init_fonts(font_paths: &[&Path]) -> (Fonts, LazyHash<FontBook>) {
 /// This function is thread-safe. If called concurrently, only one thread
 /// performs initialization; others wait and receive the shared result.
 pub fn get_fonts(font_path: Option<&Path>) -> &'static (Fonts, LazyHash<FontBook>) {
-    GLOBAL_FONTS.get_or_init(|| {
-        font_path.map_or_else(|| init_fonts(&[]), |path| init_fonts(&[path]))
-    })
+    GLOBAL_FONTS
+        .get_or_init(|| font_path.map_or_else(|| init_fonts(&[]), |path| init_fonts(&[path])))
 }
 
 #[cfg(test)]
@@ -113,7 +112,10 @@ mod tests {
     fn test_font_book_not_empty() {
         let fonts = get_fonts(None);
         // FontBook should have indexed the fonts
-        assert!(fonts.1.families().count() > 0, "Font book should have families");
+        assert!(
+            fonts.1.families().count() > 0,
+            "Font book should have families"
+        );
     }
 
     #[test]
@@ -130,6 +132,9 @@ mod tests {
         let fonts1 = get_fonts(None);
         // Second call with different path should return same fonts
         let fonts2 = get_fonts(Some(Path::new("/nonexistent")));
-        assert!(std::ptr::eq(fonts1, fonts2), "Path ignored after initialization");
+        assert!(
+            std::ptr::eq(fonts1, fonts2),
+            "Path ignored after initialization"
+        );
     }
 }

--- a/src/typst_lib/mod.rs
+++ b/src/typst_lib/mod.rs
@@ -58,10 +58,10 @@ mod world;
 
 use std::path::{Path, PathBuf};
 
+use typst::Document;
 use typst::foundations::{Label, Selector, Value};
 use typst::introspection::MetadataElem;
 use typst::utils::PicoStr;
-use typst::Document;
 
 pub use world::SystemWorld;
 
@@ -132,11 +132,7 @@ pub fn warmup_with_root(root: &Path) {
 /// * `path` - Path to the `.typ` file to compile
 /// * `root` - Project root directory for resolving imports
 /// * `label_name` - The label to query for metadata (e.g., "tola-meta")
-pub fn compile_meta(
-    path: &Path,
-    root: &Path,
-    label_name: &str,
-) -> anyhow::Result<CompileResult> {
+pub fn compile_meta(path: &Path, root: &Path, label_name: &str) -> anyhow::Result<CompileResult> {
     let _guard = acquire_test_lock();
     let (_world, document) = compile_base(path, root)?;
 
@@ -188,7 +184,10 @@ fn compile_base(
 }
 
 /// Extract metadata from a compiled document by label name.
-fn extract_meta(document: &typst_html::HtmlDocument, label_name: &str) -> Option<serde_json::Value> {
+fn extract_meta(
+    document: &typst_html::HtmlDocument,
+    label_name: &str,
+) -> Option<serde_json::Value> {
     let label = Label::new(PicoStr::intern(label_name))?;
     let introspector = document.introspector();
     let elem = introspector.query_unique(&Selector::Label(label)).ok()?;
@@ -405,9 +404,18 @@ mod tests {
 
         // Serialize to JSON to check contents
         let json: serde_json::Value = serde_json::to_value(&value).unwrap();
-        assert_eq!(json.get("title").and_then(|v| v.as_str()), Some("Test Post"));
-        assert_eq!(json.get("date").and_then(|v| v.as_str()), Some("2024-01-01"));
-        assert_eq!(json.get("author").and_then(|v| v.as_str()), Some("Test Author"));
+        assert_eq!(
+            json.get("title").and_then(|v| v.as_str()),
+            Some("Test Post")
+        );
+        assert_eq!(
+            json.get("date").and_then(|v| v.as_str()),
+            Some("2024-01-01")
+        );
+        assert_eq!(
+            json.get("author").and_then(|v| v.as_str()),
+            Some("Test Author")
+        );
     }
 
     #[test]

--- a/src/utils/category.rs
+++ b/src/utils/category.rs
@@ -104,8 +104,7 @@ pub fn normalize_path(path: &Path) -> PathBuf {
         if path.is_absolute() {
             path.to_path_buf()
         } else {
-            env::current_dir()
-                .map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+            env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
         }
     })
 }

--- a/src/utils/css.rs
+++ b/src/utils/css.rs
@@ -5,9 +5,9 @@
 //! - Tailwind CSS build integration
 
 use crate::config::SiteConfig;
-use crate::utils::exec::FilterRule;
 use crate::exec;
-use anyhow::{anyhow, Result};
+use crate::utils::exec::FilterRule;
+use anyhow::{Result, anyhow};
 use std::{
     fs,
     io::Write,
@@ -92,8 +92,12 @@ pub fn is_tailwind_input(path: &Path, config: &SiteConfig) -> bool {
 
 /// Run Tailwind CSS build for the input file.
 pub fn run_tailwind(input: &Path, output: &Path, config: &SiteConfig, quiet: bool) -> Result<()> {
-    use super::exec::{SILENT_FILTER, FilterRule};
-    let filter: &'static FilterRule = if quiet { &SILENT_FILTER } else { &TAILWIND_FILTER };
+    use super::exec::{FilterRule, SILENT_FILTER};
+    let filter: &'static FilterRule = if quiet {
+        &SILENT_FILTER
+    } else {
+        &TAILWIND_FILTER
+    };
     exec!(
         pty=true;
         filter=filter;
@@ -184,6 +188,9 @@ mod tests {
             .filter(|e| e.file_name().to_string_lossy().starts_with(".enhance-"))
             .collect();
         assert_eq!(files.len(), 1);
-        assert_eq!(files[0].file_name().to_string_lossy(), enhance_css_filename());
+        assert_eq!(
+            files[0].file_name().to_string_lossy(),
+            enhance_css_filename()
+        );
     }
 }

--- a/src/utils/exec.rs
+++ b/src/utils/exec.rs
@@ -324,9 +324,7 @@ fn exec_with_pty(
         .map_err(|_| anyhow::anyhow!("Failed to join output reader thread"))?;
 
     if !status.success() {
-        let msg = format!(
-            "Command `{name}` failed with exit code: {status:?}\n{output_str}"
-        );
+        let msg = format!("Command `{name}` failed with exit code: {status:?}\n{output_str}");
         anyhow::bail!(msg);
     }
 

--- a/src/utils/git/ignore.rs
+++ b/src/utils/git/ignore.rs
@@ -2,11 +2,11 @@ use gix::{bstr::ByteSlice, glob::wildmatch};
 
 // Constants for gix::ignore::search::pattern::Mode (which is private)
 // See: https://github.com/Byron/gitoxide/blob/main/gix-ignore/src/search/pattern.rs
-const MODE_NO_SUB_DIR: u32 = 1 << 0;      // Pattern has no internal slash (matches basename unless absolute)
+const MODE_NO_SUB_DIR: u32 = 1 << 0; // Pattern has no internal slash (matches basename unless absolute)
 // const MODE_ENDS_WITH: u32 = 1 << 1;    // Pattern ends with something (not used here directly)
-const MODE_MUST_MATCH_DIR: u32 = 1 << 2;  // Pattern ends with slash (must match directory)
-const MODE_NEGATIVE: u32 = 1 << 3;        // Pattern starts with ! (negation)
-const MODE_ABSOLUTE: u32 = 1 << 4;        // Pattern starts with / (rooted at gitignore location)
+const MODE_MUST_MATCH_DIR: u32 = 1 << 2; // Pattern ends with slash (must match directory)
+const MODE_NEGATIVE: u32 = 1 << 3; // Pattern starts with ! (negation)
+const MODE_ABSOLUTE: u32 = 1 << 4; // Pattern starts with / (rooted at gitignore location)
 
 /// Matches paths against .gitignore patterns.
 ///
@@ -83,7 +83,12 @@ mod tests {
     fn test_gix_parse_behavior() {
         let gitignore = b"/root_only\nsub/dir\n*.log\ntemp/";
         for (pattern, _, _) in gix::ignore::parse(gitignore) {
-            println!("Pattern: {:?}, Mode: {:?} (bits: {:b})", pattern.text, pattern.mode, pattern.mode.bits());
+            println!(
+                "Pattern: {:?}, Mode: {:?} (bits: {:b})",
+                pattern.text,
+                pattern.mode,
+                pattern.mode.bits()
+            );
         }
     }
 

--- a/src/utils/git/remote.rs
+++ b/src/utils/git/remote.rs
@@ -1,9 +1,6 @@
 use crate::{config::SiteConfig, exec, log};
 use anyhow::{Context, Result, bail};
-use gix::{
-    Repository, ThreadSafeRepository,
-    remote::Direction,
-};
+use gix::{Repository, ThreadSafeRepository, remote::Direction};
 use std::{fs, path::Path};
 
 use super::repo::get_repo_root;

--- a/src/utils/git/repo.rs
+++ b/src/utils/git/repo.rs
@@ -1,10 +1,6 @@
 use crate::{init::init_ignored_files, log};
 use anyhow::{Result, anyhow, bail};
-use gix::{
-    Repository, ThreadSafeRepository,
-    commit::NO_PARENT_IDS,
-    index::State,
-};
+use gix::{Repository, ThreadSafeRepository, commit::NO_PARENT_IDS, index::State};
 use std::{fs, path::Path};
 
 use super::tree::TreeBuilder;
@@ -75,7 +71,10 @@ fn get_parent_commit_ids(repo: &ThreadSafeRepository) -> Result<Vec<gix::ObjectI
     let parent_ids = repo_local
         .find_reference("refs/heads/main")
         .ok()
-        .map_or_else(|| NO_PARENT_IDS.to_vec(), |refs| vec![refs.target().id().to_owned()]);
+        .map_or_else(
+            || NO_PARENT_IDS.to_vec(),
+            |refs| vec![refs.target().id().to_owned()],
+        );
 
     Ok(parent_ids)
 }
@@ -124,7 +123,10 @@ mod tests {
             let mut head = repo_local.head().unwrap();
             let commit = head.peel_to_commit_in_place().unwrap();
 
-            assert_eq!(commit.message().unwrap().summary().to_string(), "Initial commit");
+            assert_eq!(
+                commit.message().unwrap().summary().to_string(),
+                "Initial commit"
+            );
         });
     }
 
@@ -133,7 +135,10 @@ mod tests {
         with_temp_repo(|_dir, repo| {
             let result = commit_all(repo, "   ");
             assert!(result.is_err());
-            assert_eq!(result.unwrap_err().to_string(), "Commit message cannot be empty");
+            assert_eq!(
+                result.unwrap_err().to_string(),
+                "Commit message cannot be empty"
+            );
         });
     }
 

--- a/src/utils/git/tree.rs
+++ b/src/utils/git/tree.rs
@@ -163,9 +163,21 @@ mod tests {
     #[test]
     fn test_sort_tree_entries() {
         let mut entries = vec![
-            Entry { mode: EntryKind::Blob.into(), filename: "foo.rs".into(), oid: gix::ObjectId::null(gix::hash::Kind::Sha1) },
-            Entry { mode: EntryKind::Tree.into(), filename: "foo".into(), oid: gix::ObjectId::null(gix::hash::Kind::Sha1) },
-            Entry { mode: EntryKind::Blob.into(), filename: "foo-bar".into(), oid: gix::ObjectId::null(gix::hash::Kind::Sha1) },
+            Entry {
+                mode: EntryKind::Blob.into(),
+                filename: "foo.rs".into(),
+                oid: gix::ObjectId::null(gix::hash::Kind::Sha1),
+            },
+            Entry {
+                mode: EntryKind::Tree.into(),
+                filename: "foo".into(),
+                oid: gix::ObjectId::null(gix::hash::Kind::Sha1),
+            },
+            Entry {
+                mode: EntryKind::Blob.into(),
+                filename: "foo-bar".into(),
+                oid: gix::ObjectId::null(gix::hash::Kind::Sha1),
+            },
         ];
 
         // Git sort order:

--- a/src/utils/slug.rs
+++ b/src/utils/slug.rs
@@ -655,12 +655,7 @@ mod tests {
     // Integration tests with SiteConfig
     // ========================================================================
 
-    fn make_config(
-        path_mode: &str,
-        fragment_mode: &str,
-        case: &str,
-        sep: char,
-    ) -> SiteConfig {
+    fn make_config(path_mode: &str, fragment_mode: &str, case: &str, sep: char) -> SiteConfig {
         let sep_str = if sep == '-' { "dash" } else { "underscore" };
         let toml = format!(
             r#"
@@ -766,4 +761,3 @@ mod tests {
         );
     }
 }
-

--- a/src/utils/svg/compress.rs
+++ b/src/utils/svg/compress.rs
@@ -5,16 +5,12 @@ use std::io::Write;
 use std::path::Path;
 use std::time::SystemTime;
 
+use super::{OutputFormat, Svg};
 use crate::config::{ExtractSvgType, SiteConfig};
 use crate::{exec_with_stdin, log};
-use super::{Svg, OutputFormat};
 
 /// Compress multiple SVGs in parallel
-pub fn compress_svgs_parallel(
-    svgs: &[Svg],
-    html_path: &Path,
-    config: &SiteConfig,
-) -> Result<()> {
+pub fn compress_svgs_parallel(svgs: &[Svg], html_path: &Path, config: &SiteConfig) -> Result<()> {
     let output_dir = html_path.parent().context("Invalid html path")?;
     let log_prefix = get_log_prefix(html_path, config);
     let scale = config.get_scale();

--- a/src/utils/svg/extract.rs
+++ b/src/utils/svg/extract.rs
@@ -4,11 +4,11 @@ use quick_xml::events::{BytesStart, Event};
 use quick_xml::{Reader, Writer};
 use std::io::Cursor;
 
-use crate::config::SiteConfig;
-use crate::compiler::meta::url_from_output_path;
-use crate::utils::svg::{HtmlContext, Svg, INITIAL_SVG_BUFFER_SIZE};
 use super::optimize::optimize_svg;
 use super::transform::transform_svg_attrs;
+use crate::compiler::meta::url_from_output_path;
+use crate::config::SiteConfig;
+use crate::utils::svg::{HtmlContext, INITIAL_SVG_BUFFER_SIZE, Svg};
 
 /// Extract and optimize an SVG element, writing an img placeholder to the output
 pub fn extract_svg_element(
@@ -190,7 +190,10 @@ mod tests {
         let s = String::from_utf8(captured).unwrap();
 
         // Should wrap in <svg>...</svg>
-        assert_eq!(s, r#"<svg><rect x="0" y="0" width="10" height="10"/></svg>"#);
+        assert_eq!(
+            s,
+            r#"<svg><rect x="0" y="0" width="10" height="10"/></svg>"#
+        );
     }
 
     #[test]
@@ -206,7 +209,10 @@ mod tests {
         let captured = capture_svg_content(&mut reader, &attrs).unwrap();
         let s = String::from_utf8(captured).unwrap();
 
-        assert_eq!(s, r#"<svg><g><svg viewBox="0 0 10 10"><rect/></svg></g></svg>"#);
+        assert_eq!(
+            s,
+            r#"<svg><g><svg viewBox="0 0 10 10"><rect/></svg></g></svg>"#
+        );
     }
 
     #[test]
@@ -217,8 +223,14 @@ mod tests {
         let _ = reader.read_event().unwrap();
 
         let attrs = vec![
-            Attribute { key: QName(b"width"), value: b"100".as_slice().into() },
-            Attribute { key: QName(b"height"), value: b"100".as_slice().into() },
+            Attribute {
+                key: QName(b"width"),
+                value: b"100".as_slice().into(),
+            },
+            Attribute {
+                key: QName(b"height"),
+                value: b"100".as_slice().into(),
+            },
         ];
 
         let captured = capture_svg_content(&mut reader, &attrs).unwrap();

--- a/src/utils/svg/optimize.rs
+++ b/src/utils/svg/optimize.rs
@@ -1,5 +1,5 @@
-use anyhow::{Context, Result};
 use crate::config::SiteConfig;
+use anyhow::{Context, Result};
 
 /// Optimize SVG using usvg, returning optimized bytes and dimensions.
 pub fn optimize_svg(content: &[u8], config: &SiteConfig) -> Result<(Vec<u8>, (f32, f32))> {

--- a/src/utils/svg/transform.rs
+++ b/src/utils/svg/transform.rs
@@ -1,8 +1,8 @@
+use crate::utils::svg::{SVG_PADDING_BOTTOM, SVG_PADDING_TOP};
 use anyhow::Result;
-use quick_xml::events::attributes::Attribute;
 use quick_xml::events::BytesStart;
+use quick_xml::events::attributes::Attribute;
 use quick_xml::name::QName;
-use crate::utils::svg::{SVG_PADDING_TOP, SVG_PADDING_BOTTOM};
 
 /// Transform SVG attributes (height, viewBox adjustments).
 pub fn transform_svg_attrs<'a>(elem: &'a BytesStart<'_>) -> Result<Vec<Attribute<'a>>> {
@@ -41,7 +41,9 @@ fn adjust_viewbox(attr: Attribute<'_>) -> Result<Attribute<'static>> {
 
     // Parse 4 values without allocating a Vec
     let mut iter = value.split_whitespace();
-    let (Some(s0), Some(s1), Some(s2), Some(s3)) = (iter.next(), iter.next(), iter.next(), iter.next()) else {
+    let (Some(s0), Some(s1), Some(s2), Some(s3)) =
+        (iter.next(), iter.next(), iter.next(), iter.next())
+    else {
         anyhow::bail!("Invalid viewBox: expected 4 values")
     };
 

--- a/src/utils/xml/assets.rs
+++ b/src/utils/xml/assets.rs
@@ -1,5 +1,5 @@
-use crate::config::SiteConfig;
 use crate::compiler::meta::AssetMeta;
+use crate::config::SiteConfig;
 use anyhow::Result;
 use std::collections::HashSet;
 use std::ffi::OsString;

--- a/src/utils/xml/common.rs
+++ b/src/utils/xml/common.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use quick_xml::{
-    events::{BytesEnd, BytesStart, BytesText, Event},
     Reader, Writer,
+    events::{BytesEnd, BytesStart, BytesText, Event},
 };
 use std::borrow::Cow;
 use std::io::Cursor;

--- a/src/utils/xml/head.rs
+++ b/src/utils/xml/head.rs
@@ -5,7 +5,7 @@ use quick_xml::events::{BytesEnd, Event};
 use std::io::Write;
 
 use super::assets::{compute_asset_href, compute_stylesheet_href, get_icon_mime_type};
-use super::common::{write_empty_elem, write_script, write_text_element, XmlWriter};
+use super::common::{XmlWriter, write_empty_elem, write_script, write_text_element};
 
 /// Write `<head>` section content before closing tag.
 pub fn write_head_content(writer: &mut XmlWriter, config: &SiteConfig) -> Result<()> {

--- a/src/utils/xml/link.rs
+++ b/src/utils/xml/link.rs
@@ -214,9 +214,10 @@ pub fn process_relative_link(value: &str, is_source_index: bool) -> Result<Cow<'
 pub fn is_external_link(link: &str) -> bool {
     link.find(':').is_some_and(|pos| {
         // Scheme must be non-empty
-        pos > 0 && link[..pos]
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
+        pos > 0
+            && link[..pos]
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
     })
 }
 
@@ -231,27 +232,60 @@ mod tests {
     #[test]
     fn test_relative_link_index_no_adjustment() {
         // index.typ: output is at same level, no adjustment needed
-        assert_eq!(process_relative_link("./img.png", true).unwrap(), "./img.png");
-        assert_eq!(process_relative_link("../doc.pdf", true).unwrap(), "../doc.pdf");
-        assert_eq!(process_relative_link("asset/logo.svg", true).unwrap(), "asset/logo.svg");
-        assert_eq!(process_relative_link("../../up/up.txt", true).unwrap(), "../../up/up.txt");
+        assert_eq!(
+            process_relative_link("./img.png", true).unwrap(),
+            "./img.png"
+        );
+        assert_eq!(
+            process_relative_link("../doc.pdf", true).unwrap(),
+            "../doc.pdf"
+        );
+        assert_eq!(
+            process_relative_link("asset/logo.svg", true).unwrap(),
+            "asset/logo.svg"
+        );
+        assert_eq!(
+            process_relative_link("../../up/up.txt", true).unwrap(),
+            "../../up/up.txt"
+        );
     }
 
     #[test]
     fn test_relative_link_non_index_prepend() {
         // Non-index.typ: output is one level deeper, prepend ../
-        assert_eq!(process_relative_link("./img.png", false).unwrap(), ".././img.png");
-        assert_eq!(process_relative_link("../doc.pdf", false).unwrap(), "../../doc.pdf");
-        assert_eq!(process_relative_link("asset/logo.svg", false).unwrap(), "../asset/logo.svg");
+        assert_eq!(
+            process_relative_link("./img.png", false).unwrap(),
+            ".././img.png"
+        );
+        assert_eq!(
+            process_relative_link("../doc.pdf", false).unwrap(),
+            "../../doc.pdf"
+        );
+        assert_eq!(
+            process_relative_link("asset/logo.svg", false).unwrap(),
+            "../asset/logo.svg"
+        );
     }
 
     #[test]
     fn test_relative_link_external_unchanged() {
         // External links: unchanged regardless of is_source_index
-        assert_eq!(process_relative_link("https://example.com", true).unwrap(), "https://example.com");
-        assert_eq!(process_relative_link("https://example.com", false).unwrap(), "https://example.com");
-        assert_eq!(process_relative_link("mailto:user@example.com", true).unwrap(), "mailto:user@example.com");
-        assert_eq!(process_relative_link("tel:+1234567890", false).unwrap(), "tel:+1234567890");
+        assert_eq!(
+            process_relative_link("https://example.com", true).unwrap(),
+            "https://example.com"
+        );
+        assert_eq!(
+            process_relative_link("https://example.com", false).unwrap(),
+            "https://example.com"
+        );
+        assert_eq!(
+            process_relative_link("mailto:user@example.com", true).unwrap(),
+            "mailto:user@example.com"
+        );
+        assert_eq!(
+            process_relative_link("tel:+1234567890", false).unwrap(),
+            "tel:+1234567890"
+        );
     }
 
     // ========================================================================
@@ -296,8 +330,14 @@ mod tests {
     #[test]
     fn test_fragment_link_simple() {
         let config = SiteConfig::default();
-        assert_eq!(process_fragment_link("#section", &config).unwrap(), "#section");
-        assert_eq!(process_fragment_link("#my-heading", &config).unwrap(), "#my-heading");
+        assert_eq!(
+            process_fragment_link("#section", &config).unwrap(),
+            "#section"
+        );
+        assert_eq!(
+            process_fragment_link("#my-heading", &config).unwrap(),
+            "#my-heading"
+        );
     }
 
     #[test]

--- a/src/utils/xml/processor.rs
+++ b/src/utils/xml/processor.rs
@@ -1,18 +1,16 @@
 use crate::config::SiteConfig;
 use crate::utils::slug::slugify_fragment;
-use crate::utils::svg::{compress_svgs_parallel, extract_svg_element, HtmlContext, Svg};
+use crate::utils::svg::{HtmlContext, Svg, compress_svgs_parallel, extract_svg_element};
 use anyhow::Result;
 use quick_xml::{
-    events::{BytesEnd, BytesStart, Event},
     Reader, Writer,
+    events::{BytesEnd, BytesStart, Event},
 };
 use std::io::Cursor;
 use std::path::Path;
 use std::str;
 
-use super::common::{
-    create_xml_reader, rebuild_elem, rebuild_elem_try, XmlWriter,
-};
+use super::common::{XmlWriter, create_xml_reader, rebuild_elem, rebuild_elem_try};
 use super::head::write_head_content;
 use super::link::process_link_value;
 


### PR DESCRIPTION
This PR adds a workflow that checks that every file is formatted by `rustfmt`

Currently this repository is not formatted by `rustfmt`. This adds friction to contributing, because in my editor I have auto-format enabled for Rust.

When I make any changes to a file, I save, and it just formats the rest of the file. Because I don't want stray formatting changes in my PR, I have to disable auto-format, manually select which git hunks to stage and discard, and then commit that